### PR TITLE
[fix] firstPage에 ChakraProvider 삭제

### DIFF
--- a/music/src/Pages/FirstTest/FirstPage1.js
+++ b/music/src/Pages/FirstTest/FirstPage1.js
@@ -1,6 +1,5 @@
 import React from "react";
 import {useState, useRef} from "react";
-import { ChakraProvider } from '@chakra-ui/react';
 import ProgressBar from "@ramonak/react-progress-bar";
 import { supabase } from '../../supabaseClient';
 
@@ -71,7 +70,6 @@ const FirstPage1 = () => {
 
 
     return (
-        <ChakraProvider>
         <div className="firstPage">
             <div className="progress">
             <ProgressBar
@@ -111,7 +109,6 @@ const FirstPage1 = () => {
             </div>
             <NextButton to="/SecondPage" rockCount={1} jazzCount={2} RbCount={2}/>
         </div>
-        </ChakraProvider>
     );
 };
 


### PR DESCRIPTION
### ChakraProvider 삭제

-  firstPage와 firstPage1의 배치가 달라지는 문제가 발생해서 div 전체를 감싸고 있던 <code>ChakraProvider</code>를 삭제하여 배치를 통일시켰습니다.