### PR TITLE
[feat] prettier, eslint 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "useTabs": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "auto"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,62 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import pluginJs from '@eslint/js';
+import prettier from 'eslint-config-prettier';
+import globals from 'globals';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// mimic CommonJS variables -- not needed if using CommonJS
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+export default [
+  pluginJs.configs.recommended,
+  ...compat.extends('eslint-config-airbnb-base'),
+  prettier,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        // 'jest' is not defined 오류
+        ...globals.jest,
+      },
+      ecmaVersion: 'latest',
+    },
+    rules: {
+      // package import를 제외한 모든 import 구문에 대해 확장자를 사용하도록 강제
+      'import/extensions': ['error', 'ignorePackages'],
+      // 기타 사소한 오류 해결
+      'import/prefer-default-export': 'off',
+      'class-methods-use-this': 'off',
+      'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
+      'lines-between-class-members': [
+        'error',
+        'always',
+        { exceptAfterSingleLine: true },
+      ],
+    },
+  },
+  {
+    // 프로그래밍 요구 사항 적용
+    files: ['music/src/**/*.js'],
+    rules: {
+      // 함수의 매개변수 개수 제한
+      'max-params': ['error', 3],
+      // 함수의 길이 제한
+      'max-lines-per-function': ['error', { max: 20 }],
+    },
+  },
+  {
+    files: ['eslint.config.js'],
+    rules: {
+      // eslint.config.js 파일에서만 'no-underscore-dangle' 규칙을 비활성화
+      'no-underscore-dangle': 'off',
+      // package.json 파일이 위치한 프로젝트 루트 디렉토리 경로를 명시
+      'import/no-extraneous-dependencies': ['error', { packageDir: __dirname }],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "wap_web8",
+  "version": "1.0.0",
+  "description": "**사용자의 취향 장르**를 판별하고 그에 맞는 **플레이리스트**를 제공하기 위해 설계된 **웹 애플리케이션**입니다.  <br/>",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
+    "@eslint/js": "^9.14.0",
+    "eslint": "^8.57.1",
+    "eslint-plugin-react": "^7.37.2",
+    "globals": "^15.12.0"
+  },
+  "dependencies": {
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.31.0"
+  }
+}


### PR DESCRIPTION
###  prettier 규칙
- 작은 따옴표 사용
- 명령문 끝에 세미콜론 
- 들여쓰기에 사용할 스페이스는 2개
- 한 줄의 최대 길이 80

```
{
  "singleQuote": true,
  "semi": true,
  "useTabs": false,
  "tabWidth": 2,
  "trailingComma": "all",
  "printWidth": 80,
  "bracketSpacing": true,
  "arrowParens": "always",
  "endOfLine": "auto"
}

```

### eslint

- prettier와의 충돌 방지
```javascript
import prettier from 'eslint-config-prettier';
```

- Airbnb 규칙 추가
```javascript
...compat.extends('eslint-config-airbnb-base'),
```

- 파일 경로
```javascript
files: ['music/src/**/*.js'],
```

- 함수 규칙
```javascript
rules: {
      // 함수의 매개변수 개수 제한
      'max-params': ['error', 3],
      // 함수의 길이 제한
      'max-lines-per-function': ['error', { max: 20 }],
    },
```

### why?

-> 코드의 전체적인 일관성 지키기
-> 가독성 높이기