### PR TITLE
[fix] 두번째 테스트 박스 width 반응형 추가

### DIFF
--- a/music/src/Pages/SecondTest/Button/SecondBtn.css
+++ b/music/src/Pages/SecondTest/Button/SecondBtn.css
@@ -8,6 +8,7 @@
   background-color: #d6ff32;
   padding: 10px 40px;
   font-size: medium;
+  border-color: transparent;
   color: black;
   border-radius: 15px;
   font-weight: bold;
@@ -19,5 +20,5 @@
 }
 
 .SecondBtn button:hover {
-  background-color: #88a221;
+  background-color: #a9c246;
 }

--- a/music/src/Pages/SecondTest/SecondPage.css
+++ b/music/src/Pages/SecondTest/SecondPage.css
@@ -65,12 +65,21 @@
 }
 
 @media screen and (min-width: 698px) and (max-width: 1024px) {
+  .num2 {
+    width: 80%;
+    margin-left: 10%;
+  }
+
   .num2 h3 {
     font-size: 20px;
   }
 }
 
 @media screen and (max-width: 698px) {
+  .num2 {
+    width: 80%;
+    margin-left: 10%;
+  }
   .num2 h3 {
     font-size: 15px;
   }

--- a/music/src/Pages/SecondTest/SecondPage.css
+++ b/music/src/Pages/SecondTest/SecondPage.css
@@ -32,7 +32,6 @@
   margin-left: 20%;
   margin-right: 20%;
   margin-bottom: 10%;
-  padding: 10px 10px;
 }
 
 .num2 h3 {


### PR DESCRIPTION
### width 반응형 추가

- 텍스트가 길어 체크박스와 겹치는 문제 발생
- 너비 늘림으로써 겹침 문제 해소 

### 다음으로 버튼 hover색 변경

- 변경 전
<img width="156" alt="스크린샷 2024-11-17 17 46 29" src="https://github.com/user-attachments/assets/807a99eb-bbee-4981-90a0-baeb6f4242c0">

- 변경 후 
<img width="183" alt="스크린샷 2024-11-17 17 45 42" src="https://github.com/user-attachments/assets/33def5b6-b4b4-40fe-988b-1c4073d0874a">


### 이슈

- 텍스트와 체크박스가 여전히 겹쳐서 다른 방법 고민

1. 폰트 사이즈 줄이기
2. 텍스트 수 줄이기