### PR TITLE
[fix] 타이틀 변경 및 다음으로 버튼 height추가

### DIFF
--- a/music/src/App.css
+++ b/music/src/App.css
@@ -193,3 +193,27 @@ body {
     font-size: 25px;
   }
 }
+
+@media screen and (min-width: 698px) and (max-width: 1024px) {
+  .Main h2 {
+    left: 60%;
+    font-size: 30px;
+  }
+
+  .Main h1 {
+    font-size: 100px;
+    font-weight: 600;
+  }
+}
+
+@media screen and (max-width: 698px) {
+  .Main h2 {
+    left: 30%;
+    font-size: 30px;
+  }
+
+  .Main h1 {
+    font-size: 100px;
+    font-weight: 600;
+  }
+}

--- a/music/src/Pages/FirstTest/FirstPage.css
+++ b/music/src/Pages/FirstTest/FirstPage.css
@@ -86,6 +86,10 @@
   z-index: 1000;
 }
 
+.nextButton {
+  height: 100px;
+}
+
 @media screen and (min-width: 698px) and (max-width: 1024px) {
   .firstPage {
     background-image: url('/public/ipadPro.gif') !important;

--- a/music/src/Pages/FirstTest/FirstPage.js
+++ b/music/src/Pages/FirstTest/FirstPage.js
@@ -83,12 +83,14 @@ const FirstPage = () => {
               <audio ref={(el) => (audioRefs.current[item.audio] = el)} />
             </div>
           ))}
-          <NextButton
-            to="/FirstPage1"
-            popCount={2}
-            hipCount={2}
-            rockCount={1}
-          />
+          <div className="nextButton">
+            <NextButton
+              to="/FirstPage1"
+              popCount={2}
+              hipCount={2}
+              rockCount={1}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/FirstTest/FirstPage1.js
+++ b/music/src/Pages/FirstTest/FirstPage1.js
@@ -82,12 +82,15 @@ const FirstPage1 = () => {
               <audio ref={(el) => (audioRefs.current[item.audio] = el)} />
             </div>
           ))}
-          <NextButton
-            to="/SecondPage"
-            rockCount={1}
-            jazzCount={2}
-            RbCount={2}
-          />
+
+          <div className="nextButton">
+            <NextButton
+              to="/SecondPage"
+              popCount={2}
+              hipCount={2}
+              rockCount={1}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/Main/Main.js
+++ b/music/src/Pages/Main/Main.js
@@ -69,7 +69,7 @@ const Main = () => {
   return (
     <div className="Main">
       <SoundIcon isPlaying={isPlaying} playMusic={playMusic} />
-      <MainText title="숨겨진 나의 음악" subtitle="DNA" />
+      <MainText title="숨겨진 나의 음악" subtitle="Dopamine" />
       <CautionText />
       <StartButton />
     </div>

--- a/music/src/Pages/Result/Hip.js
+++ b/music/src/Pages/Result/Hip.js
@@ -96,7 +96,7 @@ const Hip = () => {
     <ChakraProvider>
       <div className="body">
         <div className="Top">
-          <h3>당신의 음악 DNA는</h3>
+          <h3>당신의 음악 Dopamine은</h3>
           <LazyImage src="/result/hiphop_result.webp" width="300" height="50" />
         </div>
 

--- a/music/src/Pages/Result/Jazz.js
+++ b/music/src/Pages/Result/Jazz.js
@@ -102,7 +102,7 @@ const Jazz = () => {
     <ChakraProvider>
       <div className="body">
         <div className="Top">
-          <h3>당신의 음악 DNA는</h3>
+          <h3>당신의 음악 Dopamine은</h3>
           <LazyImage src="/result/jazz_result.webp" width="300" height="50" />
         </div>
 

--- a/music/src/Pages/Result/Pop.js
+++ b/music/src/Pages/Result/Pop.js
@@ -99,7 +99,7 @@ const Pop = () => {
     <ChakraProvider>
       <div className="body">
         <div className="Top">
-          <h3>당신의 음악 DNA는</h3>
+          <h3>당신의 음악 Dopamine은</h3>
           <LazyImage
             src="/result/pop_result.webp"
             width="400"

--- a/music/src/Pages/Result/Rb.js
+++ b/music/src/Pages/Result/Rb.js
@@ -96,7 +96,7 @@ const Rb = () => {
     <ChakraProvider>
       <div className="body">
         <div className="Top">
-          <h3>당신의 음악 DNA는</h3>
+          <h3>당신의 음악 Dopamine은</h3>
           <LazyImage src="/result/rb_result.webp" width="300" height="50" />
         </div>
 

--- a/music/src/Pages/Result/Rock.js
+++ b/music/src/Pages/Result/Rock.js
@@ -102,7 +102,7 @@ const Rock = () => {
     <ChakraProvider>
       <div className="body">
         <div className="Top">
-          <h3>당신의 음악 DNA는</h3>
+          <h3>당신의 음악 Dopamine은</h3>
           <LazyImage src="/result/rock_result.webp" width="300" height="50" />
         </div>
 

--- a/music/src/Pages/SecondTest/SecondPage.css
+++ b/music/src/Pages/SecondTest/SecondPage.css
@@ -64,6 +64,10 @@
   margin-right: 80px;
 }
 
+.secondButton {
+  height: 100px;
+}
+
 @media screen and (min-width: 698px) and (max-width: 1024px) {
   .num2 {
     width: 80%;

--- a/music/src/Pages/SecondTest/SecondPage.js
+++ b/music/src/Pages/SecondTest/SecondPage.js
@@ -47,10 +47,18 @@ const SecondPage = () => {
               <PopBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to="/SecondPage1"
-            ids={['DancePop1', 'ElecPop1', 'BritPop1', 'IndiPop1', 'LatinPop1']}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to="/SecondPage1"
+              ids={[
+                'DancePop1',
+                'ElecPop1',
+                'BritPop1',
+                'IndiPop1',
+                'LatinPop1',
+              ]}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/SecondTest/SecondPage1.js
+++ b/music/src/Pages/SecondTest/SecondPage1.js
@@ -47,16 +47,18 @@ const SecondPage1 = () => {
               <JazzBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to="/SecondPage2"
-            ids={[
-              'LatinJazz1',
-              'SwingJazz1',
-              'SoulJazz1',
-              'FreeJazz1',
-              'BibobJazz1',
-            ]}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to="/SecondPage2"
+              ids={[
+                'LatinJazz1',
+                'SwingJazz1',
+                'SoulJazz1',
+                'FreeJazz1',
+                'BibobJazz1',
+              ]}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/SecondTest/SecondPage2.js
+++ b/music/src/Pages/SecondTest/SecondPage2.js
@@ -47,10 +47,18 @@ const SecondPage2 = () => {
               <HipBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to="/SecondPage3"
-            ids={['DrillHip1', 'TrapHip1', 'AlterHip1', 'RageHip1', 'BoomHip1']}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to="/SecondPage3"
+              ids={[
+                'DrillHip1',
+                'TrapHip1',
+                'AlterHip1',
+                'RageHip1',
+                'BoomHip1',
+              ]}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/SecondTest/SecondPage3.js
+++ b/music/src/Pages/SecondTest/SecondPage3.js
@@ -47,16 +47,18 @@ const SecondPage3 = () => {
               <RockBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to="/SecondPage4"
-            ids={[
-              'ProRock1',
-              'HeavyRock1',
-              'AlterRock1',
-              'PunkRock1',
-              'ShowRock1',
-            ]}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to="/SecondPage4"
+              ids={[
+                'ProRock1',
+                'HeavyRock1',
+                'AlterRock1',
+                'PunkRock1',
+                'ShowRock1',
+              ]}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/SecondTest/SecondPage4.js
+++ b/music/src/Pages/SecondTest/SecondPage4.js
@@ -47,10 +47,18 @@ const SecondPage4 = () => {
               <PopBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to="/SecondPage5"
-            ids={['DancePop2', 'ElecPop2', 'BritPop2', 'IndiPop2', 'LatinPop2']}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to="/SecondPage5"
+              ids={[
+                'DancePop2',
+                'ElecPop2',
+                'BritPop2',
+                'IndiPop2',
+                'LatinPop2',
+              ]}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/SecondTest/SecondPage5.js
+++ b/music/src/Pages/SecondTest/SecondPage5.js
@@ -47,16 +47,18 @@ const SecondPage5 = () => {
               <JazzBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to="/SecondPage6"
-            ids={[
-              'LatinJazz2',
-              'SwingJazz2',
-              'SoulJazz2',
-              'FreeJazz2',
-              'BibobJazz2',
-            ]}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to="/SecondPage6"
+              ids={[
+                'LatinJazz2',
+                'SwingJazz2',
+                'SoulJazz2',
+                'FreeJazz2',
+                'BibobJazz2',
+              ]}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/SecondTest/SecondPage6.js
+++ b/music/src/Pages/SecondTest/SecondPage6.js
@@ -47,10 +47,18 @@ const SecondPage6 = () => {
               <HipBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to="/SecondPage7"
-            ids={['DrillHip2', 'TrapHip2', 'AlterHip2', 'RageHip2', 'BoomHip2']}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to="/SecondPage7"
+              ids={[
+                'DrillHip2',
+                'TrapHip2',
+                'AlterHip2',
+                'RageHip2',
+                'BoomHip2',
+              ]}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/SecondTest/SecondPage7.js
+++ b/music/src/Pages/SecondTest/SecondPage7.js
@@ -47,16 +47,18 @@ const SecondPage7 = () => {
               <RockBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to="/SecondPage8"
-            ids={[
-              'ProRock2',
-              'HeavyRock2',
-              'AlterRock2',
-              'PunkRock2',
-              'ShowRock2',
-            ]}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to="/SecondPage8"
+              ids={[
+                'ProRock2',
+                'HeavyRock2',
+                'AlterRock2',
+                'PunkRock2',
+                'ShowRock2',
+              ]}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/SecondTest/SecondPage8.js
+++ b/music/src/Pages/SecondTest/SecondPage8.js
@@ -47,10 +47,12 @@ const SecondPage8 = () => {
               <RbBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to="/SecondPage9"
-            ids={['NeoRB2', 'ComRB2', 'PunkRB2', 'SoulRB2', 'AlterRB2']}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to="/SecondPage9"
+              ids={['NeoRB2', 'ComRB2', 'PunkRB2', 'SoulRB2', 'AlterRB2']}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>

--- a/music/src/Pages/SecondTest/SecondPage9.js
+++ b/music/src/Pages/SecondTest/SecondPage9.js
@@ -136,11 +136,13 @@ const SecondPage9 = () => {
               <RbBox id={item.id} onNext={() => handleScrollToNext(index)} />
             </div>
           ))}
-          <SecondBtn
-            to={`/${Result}`}
-            ids={['NeoRB1', 'ComRB1', 'PunkRB1', 'SoulRB1', 'AlterRB1']}
-            onCompleteButtonClick={completeButton}
-          />
+          <div className="secondButton">
+            <SecondBtn
+              to={`/${Result}`}
+              ids={['NeoRB1', 'ComRB1', 'PunkRB1', 'SoulRB1', 'AlterRB1']}
+              onCompleteButtonClick={completeButton}
+            />
+          </div>
         </div>
       )}
     </ScrollToNext>


### PR DESCRIPTION
## 타이틀 변경

### 🏎️ 변경 이유
컨셉은 다르지만 기존 music DNA과 멜론에서 쓰는 music DNA 이름과 겹치는 문제가 있었다.
그래서 DNA -> Dopamine으로 변경했다.

## 다음버튼 아래 공백 추가

### 🏎️ 변경 이유
<img width="930" alt="스크린샷 2024-12-08 23 17 47" src="https://github.com/user-attachments/assets/70befd91-adf6-495b-b186-9939613a2d11">
위 사진처럼 아래의 공백이 없어 불편하다는 피드백을 받았다.

### 🏎️ 변경 후
<img width="963" alt="스크린샷 2024-12-08 23 18 57" src="https://github.com/user-attachments/assets/48f4457c-48f9-4072-bc6b-7175f2219e53">
