### PR TITLE
[fix] DNA text 왼쪽으로 이동

### DIFF
--- a/music/src/App.css
+++ b/music/src/App.css
@@ -213,7 +213,7 @@ body {
   }
 
   .Main h1 {
-    left: 30%;
+    left: 20%;
     font-size: 100px;
     font-weight: 600;
   }


### PR DESCRIPTION
### 변경사항
- 메인 페이지 DNA 텍스트 left비율 10퍼센트 낮춤