### PR TITLE
[feat] 모바일 responsive hook 추가

### DIFF
--- a/music/src/Pages/Result/Jazz.js
+++ b/music/src/Pages/Result/Jazz.js
@@ -23,9 +23,12 @@ import {
 import Share from '../../Components/Share/Share';
 import CommonModal from '../../Components/modal/Modal';
 import LazyImage from '../../Components/Image/LazyImage';
+import useIsMobile from '../../hooks/useIsMobile';
 import './Result.css';
 
 const Jazz = () => {
+  const isMobile = useIsMobile(698);
+
   const JazzValue = useRecoilValue(JazzValueState);
 
   useEffect(() => {
@@ -115,6 +118,7 @@ const Jazz = () => {
                 Stan Getz
               </td>
               <td>
+                {isMobile && <br />}
                 <span>Swing</span>
                 <LazyImage src="/jazz_singer2.webp" alt="Benny Goodman" />
                 Benny Goodman
@@ -125,6 +129,7 @@ const Jazz = () => {
                 Jimmy Smith
               </td>
               <td>
+                {isMobile && <br />}
                 <span>Free</span>
                 <LazyImage src="/jazz_singer4.webp" alt="Ornette Coleman" />
                 Ornette Coleman

--- a/music/src/Pages/Result/Pop.js
+++ b/music/src/Pages/Result/Pop.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import './Result.css';
 import CommonModal from '../../Components/modal/Modal';
 
@@ -23,8 +23,11 @@ import {
 
 import Share from '../../Components/Share/Share';
 import LazyImage from '../../Components/Image/LazyImage';
+import useIsMobie from '../../hooks/useIsMobile';
 
 const Pop = () => {
+  const isMobile = useIsMobie(698);
+
   const PopValue = useRecoilValue(PopValueState);
 
   useEffect(() => {
@@ -139,6 +142,7 @@ const Pop = () => {
                 The Smiths
               </td>
               <td>
+                {isMobile && <br />}
                 <span>Latin</span>
                 <LazyImage
                   src="/pop_singer4.webp"

--- a/music/src/Pages/Result/Pop.js
+++ b/music/src/Pages/Result/Pop.js
@@ -23,10 +23,10 @@ import {
 
 import Share from '../../Components/Share/Share';
 import LazyImage from '../../Components/Image/LazyImage';
-import useIsMobie from '../../hooks/useIsMobile';
+import useIsMobile from '../../hooks/useIsMobile';
 
 const Pop = () => {
-  const isMobile = useIsMobie(698);
+  const isMobile = useIsMobile(698);
 
   const PopValue = useRecoilValue(PopValueState);
 

--- a/music/src/hooks/useIsMobile.js
+++ b/music/src/hooks/useIsMobile.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-const useIsMobie = (breakPoint = 698) => {
+const useIsMobile = (breakPoint = 698) => {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 698);
 
   useEffect(() => {
@@ -14,4 +14,4 @@ const useIsMobie = (breakPoint = 698) => {
   return isMobile;
 };
 
-export default useIsMobie;
+export default useIsMobile;

--- a/music/src/hooks/useIsMobile.js
+++ b/music/src/hooks/useIsMobile.js
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+const useIsMobie = (breakPoint = 698) => {
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 698);
+
+  useEffect(() => {
+    const detectResize = () => {
+      setIsMobile(window.innerWidth < 698);
+    };
+    window.addEventListener('resize', detectResize);
+    return () => window.removeEventListener('resize', detectResize);
+  }, [breakPoint]);
+
+  return isMobile;
+};
+
+export default useIsMobie;


### PR DESCRIPTION
### 변경사항

- responsive hook을 추가했습니다.
- 가수이름이 두 줄이상 넘어가면 가장 위에 br을 추가하였습니다.

### 모바일 훅
```javascript
import { useState, useEffect } from 'react';

const useIsMobie = (breakPoint = 698) => {
  const [isMobile, setIsMobile] = useState(window.innerWidth < 698);

  useEffect(() => {
    const detectResize = () => {
      setIsMobile(window.innerWidth < 698);
    };
    window.addEventListener('resize', detectResize);
    return () => window.removeEventListener('resize', detectResize);
  }, [breakPoint]);

  return isMobile;
};

export default useIsMobie;
```
- 698px 미만이라면 <code>useEffect</code>로 원하는 이벤트를 실행할 수 있습니다.

### 적용예시

기존에는 두 글자 이상의 가수이름이 왔을 때 전체적인 위치가 통일되지 못했습니다.
<img width="375" alt="스크린샷 2024-12-23 16 10 26" src="https://github.com/user-attachments/assets/e27d6c83-97a6-43c6-8b77-d7dd874ffcb1" />
```javascript
import useIsMobie from '../../hooks/useIsMobile';

const isMobile = useIsMobie(698);
 <td>
     {isMobile && <br />}
       <span>Latin</span>
                <LazyImage
                  src="/pop_singer4.webp"
                  loading="lazy"
                  alt="Camila Cabello"
         />
      Camila Cabello
</td>
```
변경 후에 위치를 통일하였습니다.
<img width="376" alt="스크린샷 2024-12-23 16 14 29" src="https://github.com/user-attachments/assets/05757d57-ed2b-45ab-9e65-399d5b8230f3" />
